### PR TITLE
Fix configuration

### DIFF
--- a/command/update/command.go
+++ b/command/update/command.go
@@ -140,6 +140,8 @@ func (c *Command) execute() error {
 		}
 
 		k8sConfig := k8sclient.ClientsConfig{
+			Logger: c.logger,
+
 			RestConfig: restConfig,
 		}
 


### PR DESCRIPTION
Towards: giantswarm/giantswarm#6302

https://github.com/giantswarm/k8s-endpoint-updater/pull/23 wasn't complete. This should fix the problem found during testing kvm-operator, on test cluster master was failing to start, kvm-endpoint-updater container is crashing with:

```
$ k logs master-w3q0f-546b7d4b66-jgvf6 -c k8s-endpoint-updater -n eavp2
{"caller":"github.com/giantswarm/k8s-endpoint-updater/command/update/command.go:100","info":"start adding annotations to KVM pod","time":"2019-10-11T09:42:15.027132+00:00"}
{"caller":"github.com/giantswarm/k8s-endpoint-updater/vendor/github.com/giantswarm/operatorkit/client/k8srestconfig/k8s_rest_config.go:148","level":"debug","message":"creating in-cluster REST config","time":"2019-10-11T09:42:15.027175+00:00"}
{"caller":"github.com/giantswarm/k8s-endpoint-updater/vendor/github.com/giantswarm/operatorkit/client/k8srestconfig/k8s_rest_config.go:155","level":"debug","message":"created in-cluster REST config","time":"2019-10-11T09:42:15.027476+00:00"}
{"caller":"github.com/giantswarm/k8s-endpoint-updater/command/update/command.go:110","error":"[{/go/src/github.com/giantswarm/k8s-endpoint-updater/command/update/command.go:110: } {/go/src/github.com/giantswarm/k8s-endpoint-updater/command/update/command.go:148: } {/go/src/github.com/giantswarm/k8s-endpoint-updater/vendor/github.com/giantswarm/k8sclient/clients.go:36: k8sclient.ClientsConfig.Logger must not be empty} {invalid config error}]","time":"2019-10-11T09:42:15.027548+00:00"}
```